### PR TITLE
Refactor routes

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -28,9 +28,9 @@ app.use(express.static(path.join(__dirname, "../frontend/build")));
 
 
 // route setup
-app.use("/posts", tokenChecker, postsRouter);
-app.use("/tokens", authenticationRouter);
-app.use("/users", usersRouter);
+app.use("/api/posts", tokenChecker, postsRouter);
+app.use("/api/tokens", authenticationRouter);
+app.use("/api/users", usersRouter);
 
 
 // When in production the backend will forward all requests to the production client, (which doesn't live on a server)

--- a/api/spec/controllers/authentication.spec.js
+++ b/api/spec/controllers/authentication.spec.js
@@ -24,7 +24,7 @@ describe("/tokens", () => {
 
   test("a token is returned when creds are valid", async () => {
     let response = await request(app)
-      .post("/tokens")
+      .post("/api/tokens")
       .send({email: "test@test.com", password: "12345678"})
     expect(response.status).toEqual(201)
     expect(response.body.token).not.toEqual(undefined)
@@ -34,7 +34,7 @@ describe("/tokens", () => {
 
   test("a token is not returned when creds are invalid", async () => {
     let response = await request(app)
-      .post("/tokens")
+      .post("/api/tokens")
       .send({email: "test@test.com", password: "1234"})
     expect(response.status).toEqual(401)
     expect(response.body.token).toEqual(undefined)

--- a/api/spec/controllers/posts.spec.js
+++ b/api/spec/controllers/posts.spec.js
@@ -33,7 +33,7 @@ describe("/posts", () => {
   describe("POST, when token is present", () => {
     test("responds with a 201", async () => {
       let response = await request(app)
-        .post("/posts")
+        .post("/api/posts")
         .set("Authorization", `Bearer ${token}`)
         .send({ message: "hello world", token: token });
       expect(response.status).toEqual(201);
@@ -41,7 +41,7 @@ describe("/posts", () => {
   
     test("creates a new post", async () => {
       await request(app)
-        .post("/posts")
+        .post("/api/posts")
         .set("Authorization", `Bearer ${token}`)
         .send({ message: "hello world", image:"picture.jpg", comments:[], token: token });
       let posts = await Post.find().lean();
@@ -53,7 +53,7 @@ describe("/posts", () => {
   
     test("returns a new token", async () => {
       let response = await request(app)
-        .post("/posts")
+        .post("/api/posts")
         .set("Authorization", `Bearer ${token}`)
         .send({ message: "hello world", token: token })
       let newPayload = JWT.decode(response.body.token, process.env.JWT_SECRET);
@@ -65,14 +65,14 @@ describe("/posts", () => {
   describe("POST, when token is missing", () => {
     test("responds with a 401", async () => {
       let response = await request(app)
-        .post("/posts")
+        .post("/api/posts")
         .send({ message: "hello again world" });
       expect(response.status).toEqual(401);
     });
   
     test("a post is not created", async () => {
       await request(app)
-        .post("/posts")
+        .post("/api/posts")
         .send({ message: "hello again world" });
       let posts = await Post.find();
       expect(posts.length).toEqual(0);
@@ -80,7 +80,7 @@ describe("/posts", () => {
   
     test("a token is not returned", async () => {
       let response = await request(app)
-        .post("/posts")
+        .post("/api/posts")
         .send({ message: "hello again world" });
       expect(response.body.token).toEqual(undefined);
     });
@@ -89,15 +89,15 @@ describe("/posts", () => {
   describe("GET, when token is present", () => {
     test("returns every post in the collection", async () => {
     await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "second world", image: "picture.jpg", token: token });
       let response = await request(app)
-        .get("/posts")
+        .get("/api/posts")
         .set("Authorization", `Bearer ${token}`)
         .send({token: token});
       let messages = response.body.posts.map((post) => ( post.message ));
@@ -107,11 +107,11 @@ describe("/posts", () => {
 
     test("the response code is 200", async () => {
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let response = await request(app)
-        .get("/posts")
+        .get("/api/posts")
         .set("Authorization", `Bearer ${token}`)
         .send({token: token});
       expect(response.status).toEqual(200);
@@ -119,11 +119,11 @@ describe("/posts", () => {
 
     test("returns a new token", async () => {
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let response = await request(app)
-        .get("/posts")
+        .get("/api/posts")
         .set("Authorization", `Bearer ${token}`)
         .send({token: token});
       let newPayload = JWT.decode(response.body.token, process.env.JWT_SECRET);
@@ -135,22 +135,22 @@ describe("/posts", () => {
   describe("GET, when token is missing", () => {
     test("returns no posts", async () => {
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let response = await request(app)
-        .get("/posts");
+        .get("/api/posts");
       expect(response.body.posts).toEqual(undefined);
     })
   });
 
     test("the response code is 401", async () => {
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let response = await request(app)
-        .get("/posts");
+        .get("/api/posts");
       expect(response.status).toEqual(401);
     })
 
@@ -159,13 +159,13 @@ describe("/posts", () => {
     test("updates correct post collection", async () => {
       const commentText = "Test Text";
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let posts = await Post.find();
       const comment = { text: commentText};
       await request(app)
-        .patch(`/posts/${posts[0]._id}`)
+        .patch(`/api/posts/${posts[0]._id}`)
         .set("Authorization", `Bearer ${token}`)
         .send({comments: comment ,token: token});
       posts = await Post.find();
@@ -177,12 +177,12 @@ describe("/posts", () => {
     test("the response code is 401", async () => {
       const comment = {"text": "Test Text"};
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let posts = await Post.find();
       let response = await request(app)
-        .patch(`/posts/${posts[posts.length -1]._id}`)
+        .patch(`/api/posts/${posts[posts.length -1]._id}`)
         .send({ id: posts[0]._id, comments: comment ,token: token});
       expect(response.status).toEqual(401);
     })
@@ -192,12 +192,12 @@ describe("/posts", () => {
     test("returns 201 and comment length to equal 1", async () => {
       const comment = {"text": "Test Text"};
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let posts = await Post.find();
       let response = await request(app)
-        .patch(`/posts/${posts[posts.length -1]._id}`)
+        .patch(`/api/posts/${posts[posts.length -1]._id}`)
         .set("Authorization", `Bearer ${token}`)
         .send({comments: comment ,token: token});
       let secondPosts = await Post.find();
@@ -210,12 +210,12 @@ describe("/posts", () => {
     test("returns the date and time when comment was created", async () => {
       const comment = {"text": "Test Text"};
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let posts = await Post.find();
       let response = await request(app)
-        .patch(`/posts/${posts[posts.length -1]._id}`)
+        .patch(`/api/posts/${posts[posts.length -1]._id}`)
         .set("Authorization", `Bearer ${token}`)
         .send({comments: comment ,token: token});
       let secondPosts = await Post.find();
@@ -230,12 +230,12 @@ describe("/posts", () => {
   describe("Patch for likes, when token is present", () => {
     test("updates likes count in correct post collection", async () => {
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let posts = await Post.find();
       let response = await request(app)
-      .patch(`/posts/${posts[posts.length -1]._id}`)
+      .patch(`/api/posts/${posts[posts.length -1]._id}`)
         .set("Authorization", `Bearer ${token}`)
         .send({likes: posts[posts.length - 1].likes, token: token});
       let newPosts = await Post.find();
@@ -247,12 +247,12 @@ describe("/posts", () => {
   describe("Patch for likes, when token is not present", () => {
     test("return status 401", async () => {
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let posts = await Post.find();
       let response = await request(app)
-      .patch(`/posts/${posts[posts.length -1]._id}`)
+      .patch(`/api/posts/${posts[posts.length -1]._id}`)
         .send({likes: 10 ,token: token});
       posts = await Post.find();
       expect(posts[0].likes).toEqual(0);
@@ -263,12 +263,12 @@ describe("/posts", () => {
   describe("Delete post by id", () => {
     test("delete's post for the given id ", async () => {
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let posts = await Post.find();
       let response = await request(app)
-      .delete(`/posts/${posts[posts.length -1]._id}`)
+      .delete(`/api/posts/${posts[posts.length -1]._id}`)
         .set("Authorization", `Bearer ${token}`)
       let newPosts = await Post.find();
       expect(newPosts.length).toEqual(0);
@@ -276,16 +276,16 @@ describe("/posts", () => {
 
     test("delete's post for the given id and the other remains", async () => {
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "test 2", image: "picture.jpg", token: token });
       let posts = await Post.find();
       let response = await request(app)
-      .delete(`/posts/${posts[posts.length -1]._id}`)
+      .delete(`/api/posts/${posts[posts.length -1]._id}`)
         .set("Authorization", `Bearer ${token}`)
       let newPosts = await Post.find();
       console.log("POSTS", newPosts)
@@ -295,12 +295,12 @@ describe("/posts", () => {
 
   test("get post by user Id", async () => {
     await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "new world", image: "picture.jpg", token: token });
       let posts = await Post.find();
       let response = await request(app)
-      .get(`/posts/user/${posts[posts.length -1].user}`)
+      .get(`/api/posts/user/${posts[posts.length -1].user}`)
         .set("Authorization", `Bearer ${token}`)
       let newPosts = await Post.find();
       expect(newPosts.length).toEqual(1);
@@ -311,7 +311,7 @@ describe("/posts", () => {
 
   test("creates a new post associated with user", async () => {
     await request(app)
-      .post("/posts")
+      .post("/api/posts")
       .set("Authorization", `Bearer ${token}`)
       .send({ message: "hello world", image:"picture.jpg",  token: token });
     let posts = await Post.find();
@@ -324,12 +324,12 @@ describe("/posts", () => {
 //test get post with user details 
   test("gets post with username and profilePic", async () => {
     await request(app)
-    .post("/posts")
+    .post("/api/posts")
     .set("Authorization", `Bearer ${token}`)
     .send({ message: "new world", image: "picture.jpg", token: token });
     
     const response = await request(app)
-      .get("/posts")
+      .get("/api/posts")
       .set("Authorization", `Bearer ${token}`);
   
     expect(response.status).toEqual(200);

--- a/api/spec/controllers/users.spec.js
+++ b/api/spec/controllers/users.spec.js
@@ -18,7 +18,7 @@ describe("/users", () => {
   describe("POST, when email and password and username are provided", () => {
     test("the response code is 201", async () => {
       let response = await request(app)
-        .post("/users")
+        .post("/api/users")
         .send({
           email: "poppy@email.com",
           password: "1234",
@@ -29,7 +29,7 @@ describe("/users", () => {
 
     test("a user is created", async () => {
       await request(app)
-        .post("/users")
+        .post("/api/users")
         .send({
           email: "scarlett@email.com",
           password: "1234",
@@ -42,7 +42,7 @@ describe("/users", () => {
 
     test("when user created profile pic added ", async () => {
       await request(app)
-        .post("/users")
+        .post("/api/users")
         .send({
           email: "scarlett@email.com",
           password: "1234",
@@ -57,7 +57,7 @@ describe("/users", () => {
 
     test("username added", async () => {
       await request(app)
-        .post("/users")
+        .post("/api/users")
         .send({
           email: "scarlett@email.com",
           password: "1234",
@@ -72,14 +72,14 @@ describe("/users", () => {
   describe("POST, when password and username is missing", () => {
     test("response code is 400", async () => {
       let response = await request(app)
-        .post("/users")
+        .post("/api/users")
         .send({ email: "skye@email.com" });
       expect(response.statusCode).toBe(400);
     });
 
     test("does not create a user when password is missing", async () => {
       await request(app)
-        .post("/users")
+        .post("/api/users")
         .send({ email: "skye@email.com", username: "myusername" });
       let users = await User.find();
       expect(users.length).toEqual(0);
@@ -87,7 +87,7 @@ describe("/users", () => {
 
     test("does not create a user when username is missing", async () => {
       await request(app)
-        .post("/users")
+        .post("/api/users")
         .send({ email: "skye@email.com", password: "hello" });
       let users = await User.find();
       expect(users.length).toEqual(0);
@@ -118,7 +118,7 @@ describe("/users", () => {
 
     test("response data is correct", async () => {
       const response = await request(app)
-        .get("/users/@me")
+        .get("/api/users/@me")
         .set("Authorization", `Bearer ${token}`)
         .send({token:token});
 
@@ -132,13 +132,13 @@ describe("/users", () => {
   describe("POST, when email is missing", () => {
     test("response code is 400", async () => {
       let response = await request(app)
-        .post("/users")
+        .post("/api/users")
         .send({ password: "1234" });
       expect(response.statusCode).toBe(400);
     });
 
     test("does not create a user", async () => {
-      await request(app).post("/users").send({ password: "1234" });
+      await request(app).post("/api/users").send({ password: "1234" });
       let users = await User.find();
       expect(users.length).toEqual(0);
     });
@@ -172,7 +172,7 @@ describe("GET /users/:id", () => {
 
   test("should return user info when authenticated and id matches", async () => {
     let response = await request(app) //defining the response -> to app -> route setup /users (happens in 101)
-      .get(`/users/${user.id}`) // get request
+      .get(`/api/users/${user.id}`) // get request
       .set("Authorization", `Bearer ${token}`); // sets the authorization header using the token
     expect(response.statusCode).toEqual(200);
     expect(response.body.email).toEqual("test@test.com");
@@ -181,19 +181,19 @@ describe("GET /users/:id", () => {
 
   test("non existant id", async () => {
     let response = await request(app)
-      .get(`/users/${mongoose.Types.ObjectId()}`)
+      .get(`/api/users/${mongoose.Types.ObjectId()}`)
       .set("Authorization", `Bearer ${token}`);
     expect(response.statusCode).toEqual(404);
   });
 
   test("no token", async () => {
-    let response = await request(app).get(`/users/${user.id}`);
+    let response = await request(app).get(`/api/users/${user.id}`);
     expect(response.statusCode).toEqual(401);
   });
 
   test("no token and unauthorised user", async () => {
     let response = await request(app).get(
-      `/users/${mongoose.Types.ObjectId()}`
+      `/api/users/${mongoose.Types.ObjectId()}`
     );
     expect(response.statusCode).toEqual(401);
   });

--- a/frontend/src/components/auth/LoginForm.cy.js
+++ b/frontend/src/components/auth/LoginForm.cy.js
@@ -2,10 +2,10 @@ import LoginForm from './LoginForm'
 const navigate = () => {}
 
 describe("Logging in", () => {
-  it("calls the /tokens endpoint", () => {
+  it("calls the /api/tokens endpoint", () => {
     cy.mount(<LoginForm navigate={navigate}/>)
 
-    cy.intercept('POST', '/tokens', { token: "fakeToken" }).as("loginRequest")
+    cy.intercept('POST', '/api/tokens', { token: "fakeToken" }).as("loginRequest")
 
     cy.get("#email").type("someone@example.com");
     cy.get("#password").type("password");

--- a/frontend/src/components/auth/LoginForm.js
+++ b/frontend/src/components/auth/LoginForm.js
@@ -17,7 +17,7 @@ const LogInForm = ({ navigate }) => {
   const handleSubmit = async (event) => {
     event.preventDefault();
 
-    let response = await fetch("/tokens", {
+    let response = await fetch("/api/tokens", {
       method: "post",
       headers: {
         "Content-Type": "application/json",

--- a/frontend/src/components/feed/Feed.cy.js
+++ b/frontend/src/components/feed/Feed.cy.js
@@ -10,7 +10,7 @@ describe("Feed", () => {
   it("Calls the /posts endpoint and lists all the posts", () => {
     window.localStorage.setItem("token", "fakeToken");
 
-    cy.intercept("GET", "/posts", (req) => {
+    cy.intercept("GET", "/api/posts", (req) => {
       req.reply({
         statusCode: 200,
         body: {
@@ -33,7 +33,7 @@ describe("Feed", () => {
 
   it("Calls the PATCH /posts endpoint and increments like count", () => {
     window.localStorage.setItem("token", "fakeToken");
-    cy.intercept("GET", "/posts", (req) => {
+    cy.intercept("GET", "/api/posts", (req) => {
       req.reply({
         statusCode: 200,
         body: {
@@ -45,7 +45,7 @@ describe("Feed", () => {
       });
     }).as("getPosts");
 
-    cy.intercept("PATCH", "/posts/1", (req) => {
+    cy.intercept("PATCH", "/api/posts/1", (req) => {
       req.reply({
         statusCode: 200,
         body: { likes: 3 },
@@ -66,7 +66,7 @@ describe("Feed", () => {
 
   it("Calls the PATCH /posts endpoint and increments like count for both messages", () => {
     window.localStorage.setItem("token", "fakeToken");
-    cy.intercept("GET", "/posts", (req) => {
+    cy.intercept("GET", "/api/posts", (req) => {
       req.reply({
         statusCode: 200,
         body: {
@@ -78,14 +78,14 @@ describe("Feed", () => {
       });
     }).as("getPosts");
 
-    cy.intercept("PATCH", "/posts/1", (req) => {
+    cy.intercept("PATCH", "/api/posts/1", (req) => {
       req.reply({
         statusCode: 200,
         body: { likes: 3 },
       });
     }).as("patchPosts");
 
-    cy.intercept("PATCH", "/posts/2", (req) => {
+    cy.intercept("PATCH", "/api/posts/2", (req) => {
       req.reply({
         statusCode: 200,
         body: { likes: 3 },
@@ -108,7 +108,7 @@ describe("Feed", () => {
 
   it("Calls the PATCH /posts endpoint and increments like count twice", () => {
     window.localStorage.setItem("token", "fakeToken");
-    cy.intercept("GET", "/posts", (req) => {
+    cy.intercept("GET", "/api/posts", (req) => {
       req.reply({
         statusCode: 200,
         body: {
@@ -120,7 +120,7 @@ describe("Feed", () => {
       });
     }).as("getPosts");
 
-    cy.intercept("PATCH", "/posts/1", (req) => {
+    cy.intercept("PATCH", "/api/posts/1", (req) => {
       req.reply({
         statusCode: 200,
         body: { likes: 3 },
@@ -148,7 +148,7 @@ describe("CreatePost",() =>{
     //set fake token to simulate authentication
     window.localStorage.setItem("token","fakeToken")
     //mock the successful response
-    cy.intercept('POST', '/posts',(req) =>{
+    cy.intercept('POST', '/api/posts',(req) =>{
         req.reply({
           statusCode: 201, 
           body:{ message: "OK" , token: "newFakeToken"},

--- a/frontend/src/components/feed/Feed.js
+++ b/frontend/src/components/feed/Feed.js
@@ -21,7 +21,7 @@ const CreatePost = ({ setPosts, token, setToken }) => {
     if (!message && !image) {
       setError("There is no content!");
     } else {
-      fetch("/posts", {
+      fetch("/api/posts", {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -91,7 +91,6 @@ const CreatePost = ({ setPosts, token, setToken }) => {
                   color="primary"
                   fullWidth
                 >
-                  
                   <b>POST</b>
                 </Button>
               </Grid>
@@ -115,7 +114,7 @@ const Feed = ({ navigate }) => {
 
   useEffect(() => {
     if (token) {
-      fetch("/posts", {
+      fetch("/api/posts", {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -124,7 +123,7 @@ const Feed = ({ navigate }) => {
         .then(async (data) => {
           window.localStorage.setItem("token", data.token);
           setToken(window.localStorage.getItem("token"));
-          const postData = data.posts?data.posts.reverse():[];
+          const postData = data.posts ? data.posts.reverse() : [];
           setPosts(postData);
         });
     } else {
@@ -133,7 +132,7 @@ const Feed = ({ navigate }) => {
   }, [navigate, token]);
 
   const updateLikes = async (post) => {
-    let response = await fetch(`/posts/${post._id}`, {
+    let response = await fetch(`/api/posts/${post._id}`, {
       method: "PATCH",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/frontend/src/components/post/Post.cy.js
+++ b/frontend/src/components/post/Post.cy.js
@@ -26,11 +26,11 @@ describe("Post", () => {
 
 describe("submitComment" ,() => {
   it('fetches patch /posts with correct, datetime, authorid, message and postID', () => {
-    cy.intercept('GET', 'users/@me', {
+    cy.intercept('GET', '/api/users/@me', {
       statusCode: 200,
       body: {username: "Barry123"}
     });
-    cy.intercept('PATCH', 'posts/15', {
+    cy.intercept('PATCH', '/api/posts/15', {
       statusCode: 200
     }).as('post-posts');
     let mockDate = new Date(2023, 5, 27, 9, 56, 16);

--- a/frontend/src/components/post/Post.js
+++ b/frontend/src/components/post/Post.js
@@ -14,7 +14,7 @@ const Post = ({ post, updateLikes }) => {
   const [token, setToken] = useState(window.localStorage.getItem("token"));
 
   const submitComment = async (commentText) => {
-    let response = await fetch("/users/@me", {
+    let response = await fetch("/api/users/@me", {
       method: "GET",
       headers: { Authorization: `Bearer ${token}` },
     });
@@ -26,7 +26,7 @@ const Post = ({ post, updateLikes }) => {
       authorName: data.username,
       commentDate: new Date(),
     };
-    response = await fetch(`/posts/${post._id}`, {
+    response = await fetch(`/api/posts/${post._id}`, {
       method: "PATCH",
       headers: {
         "Content-type": "application/json",

--- a/frontend/src/components/profilePage/ProfilePage.cy.js
+++ b/frontend/src/components/profilePage/ProfilePage.cy.js
@@ -18,14 +18,14 @@ describe("ProfilePage", () => {
     beforeEach(() => {
         window.localStorage.setItem("token", "fakeToken");
 
-        cy.intercept("GET", "/users/@me", (req) => {
+        cy.intercept("GET", "/api/users/@me", (req) => {
             req.reply({
                 statusCode: 200,
                 body: mockUser
             });
         }).as("getUser");
 
-        cy.intercept("GET", `/posts/user/${mockUser.userId}`, (req) => {
+        cy.intercept("GET", `/api/posts/user/${mockUser.userId}`, (req) => {
             req.reply({
                 statusCode: 200,
                 body: {
@@ -51,7 +51,7 @@ describe("ProfilePage", () => {
     });
 
     it("Likes a post", () => {
-        cy.intercept("PATCH", `/posts/1`, (req) => {
+        cy.intercept("PATCH", `/api/posts/1`, (req) => {
         req.reply({
             statusCode: 200,
             body: { likes: 3 }

--- a/frontend/src/components/profilePage/ProfilePage.js
+++ b/frontend/src/components/profilePage/ProfilePage.js
@@ -8,7 +8,7 @@ const ProfilePage = () => {
 
   useEffect(() => {
     const fetchProfile = async () => {
-      const response = await fetch("/users/@me", {
+      const response = await fetch("/api/users/@me", {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -28,7 +28,7 @@ const ProfilePage = () => {
   }, []);
 
   const getUserPosts = async (user) => {
-    let response = await fetch(`/posts/user/${user.userId}`, {
+    let response = await fetch(`/api/posts/user/${user.userId}`, {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -50,7 +50,7 @@ const ProfilePage = () => {
   };
 
   const updateLikes = async (post) => {
-    let response = await fetch(`/posts/${post._id}`, {
+    let response = await fetch(`/api/posts/${post._id}`, {
       method: "PATCH",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/frontend/src/components/user/SignUpForm.cy.js
+++ b/frontend/src/components/user/SignUpForm.cy.js
@@ -5,7 +5,7 @@ describe("Signing up", () => {
   it("calls the /users endpoint", () => {
     cy.mount(<SignUpForm navigate={navigate}/>)
 
-    cy.intercept('POST', '/users', { message: "OK" }).as("signUpRequest")
+    cy.intercept('POST', '/api/users', { message: "OK" }).as("signUpRequest")
 
     cy.get("#email").type("someone@example.com");
     cy.get("#password").type("password");

--- a/frontend/src/components/user/SignUpForm.js
+++ b/frontend/src/components/user/SignUpForm.js
@@ -19,7 +19,7 @@ const SignUpForm = ({ navigate }) => {
   const buttonRef = useRef();
 
   const setTokens = async () => {
-    let response = await fetch( '/tokens', {
+    let response = await fetch( '/api/tokens', {
       method: 'post',
       headers: {
         'Content-Type': 'application/json',
@@ -47,7 +47,7 @@ const SignUpForm = ({ navigate }) => {
   const handleSubmit = async (event) => {
     event.preventDefault();
 
-    fetch( '/users', {
+    fetch( '/api/users', {
       method: 'post',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
Due to production errors and the way it works, API routes cannot conflict with the frontend routes, going to routes like `posts` can often cause issues where it will make the backend call to `posts` instead of displaying the frontend feed.

To quickly mitigate the issue I have added a prefix to every single backend route with `/api` so that these routes will no longer conflict. The frontend has also been refactored (along with tests) to amend these changes.